### PR TITLE
Reflect changes made to datatypes in cloud DB on our .sql file

### DIFF
--- a/server/database.sql
+++ b/server/database.sql
@@ -11,7 +11,7 @@ CREATE TABLE Users
   user_id serial NOT NULL,
   firstname varchar(50) NOT NULL,
   lastname varchar(50) NOT NULL,
-  profilepic bytea NULL,
+  profilepic varchar(65535) NULL,
   githubhandle varchar(50) NOT NULL,
   username varchar(50) NOT NULL,
   CONSTRAINT PK_user_profile PRIMARY KEY (user_id),
@@ -32,7 +32,7 @@ CREATE TABLE Ideas
   when_start date NOT NULL,
   when_end date NULL,
   who int NOT NULL,
-  image varchar NULL DEFAULT 'https://foroalfa.org/imagenes/ilustraciones/idea.png',
+  image varchar(65535) NULL DEFAULT 'https://foroalfa.org/imagenes/ilustraciones/idea.png',
   creator_username varchar(50) NOT NULL,
   CONSTRAINT PK_ideas PRIMARY KEY (idea_id),
   CONSTRAINT FK_56 FOREIGN KEY (creator_username) REFERENCES public.User_credentials (username)


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)

## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Since we originally created the columns related to image URL data (`image` in `Ideas` table and `profilepic` in `Users` table) with either type `bytea` (v small) or  type `varchar`, a user could, at best, enter a URL **with max 255 characters**, because that is what `varchar` defaults to in Postgres when no explicit max limit is specified.

Even after noting the issue, we ran into this bug inadvertently during testing upon submit of a reasonable image URL for an Andy Wang-related idea, reproduced below:
> https://cdn.theathletic.com/app/uploads/2019/09/18160245/GettyImages-102535231-1024x683.jpg
`image` column of Ideas table was `varchar` at this time.

## Approach
<!--- How does your change address the problem? -->
Changing `varchar` to `varchar(65535)` in our existing Users and Ideas tables using `ALTER` clauses.
I decided against the `text` type, because I think that's meant for bodies of text that are expected to be much longer than even the longest URL. It would also work, I think, but I wanted to prevent introducing unnecessary overhead to the database, if possible.

The only thing that changes in the codebase is our reference sheet for setting up the tables. (you can check in the Files Changed tab of this PR)

## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->

- [A discussion on what the best data type for a DB column containing a URL is](https://stackoverflow.com/questions/219569/best-database-field-type-for-a-url)
- [Why I couldn't just use varchar(max) and had to specify specific number](https://stackoverflow.com/questions/2396225/whats-wrong-with-my-mysql-code-here-in-varcharmax-line)
- [How to change an existing column's type](https://www.postgresqltutorial.com/postgresql-change-column-type/#:~:text=To%20change%20the%20data%20type%20of%20a%20column%2C%20you%20use,after%20the%20ALTER%20TABLE%20keywords.)
- [Official (SQL) docs on CHAR and VARCHAR ](https://dev.mysql.com/doc/refman/8.0/en/char.html)

## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->

I modified our cloud elephantSQL database schema using the `ALTER` clauses:
> ![image](https://user-images.githubusercontent.com/23015394/88579439-dfb44e80-cffe-11ea-80e7-e1d1ec39bbcf.png)

As you can see (below), the formerly too-long URL for an Andy Wang wrestling photo now uploads to our database without error.
> ![image](https://user-images.githubusercontent.com/23015394/88578696-ceb70d80-cffd-11ea-9465-98131f8293c5.png)
